### PR TITLE
fix depricated showDialog() argument

### DIFF
--- a/using_alert_dialog/lib/main.dart
+++ b/using_alert_dialog/lib/main.dart
@@ -32,7 +32,7 @@ class MyHomeState extends State<MyHome> {
                 // On press of the button
                 onPressed: () {
                   // Show dialog
-                  showDialog(context: context, child: dialog);
+                  showDialog(context: context, builder: (BuildContext context) => dialog);
                 }),
           ),
         ));


### PR DESCRIPTION
@nisrulz 
Fix depricated argument in  `showDialog()`.
Flutter official document is below.
https://docs.flutter.io/flutter/material/showDialog.html

I have run and checked the iOS project. But I have not run and checked the android project because I cannot resolved android dependencies. Sorry.

Please review and merge this PR.