### PR TITLE
Updated main.dart file

### DIFF
--- a/using_tabs/lib/main.dart
+++ b/using_tabs/lib/main.dart
@@ -22,7 +22,7 @@ class MyHomeState extends State<MyHome> with SingleTickerProviderStateMixin {
    *-------------------- Setup Tabs ------------------*
    */
   // Create a tab controller
-  TabController controller;
+late TabController controller;
 
   @override
   void initState() {


### PR DESCRIPTION
Performing hot restart...
Syncing files to device Android SDK built for x86...
lib/main.dart:25:17: Error: Field 'controller' should be initialized because its type 'TabController' doesn't allow null.
 - 'TabController' is from 'package:flutter/src/material/tab_controller.dart' ('../../snap/flutter/common/flutter/packages/flutter/lib/src/material/tab_controller.dart').
  TabController controller;
                ^^^^^^^^^^
Restarted application in 256ms.

We are getting this error when we are running the program. This error can be fixed by introducing "late" variable in front of Tabcontroller Class.


