### PR TITLE
[Fixes: #110] Replaced Scaffold.of(context) with ScaffoldMessenger.of(context)

### DIFF
--- a/using_snackbar/lib/main.dart
+++ b/using_snackbar/lib/main.dart
@@ -26,7 +26,7 @@ class MyButton extends StatelessWidget {
       // On pressing the raised button
       onPressed: () {
         // show snackbar
-        Scaffold.of(context).showSnackBar(SnackBar(
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
               // set content of snackbar
               content: Text("Hello! I am SnackBar :)"),
               // set duration
@@ -36,7 +36,7 @@ class MyButton extends StatelessWidget {
                   label: "Hit Me (Action)",
                   onPressed: () {
                     // When action button is pressed, show another snackbar
-                    Scaffold.of(context).showSnackBar(SnackBar(
+                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                           content: Text(
                               "Hello! I am shown becoz you pressed Action :)"),
                         ));


### PR DESCRIPTION
<!-- * Please fill out the blanks below describing your pull request 

     * Checked checkbox should look like this: [x]
-->

**What does this implement/fix? Explain your changes**

- This PR Replaces the use of Scaffold.of(context) with ScaffoldMessenger.of(context) in `using_snackbar` project
- It closes issue #110

**Does this close any currently open issues?**
- [x] Yes
- [ ] No

**Any relevant logs, error output, bug-report etc?**

<!-- * If it’s long, please paste to https://ghostbin.com/ and insert the link here.) * -->

**Any other comments?**

+ **Where has this been tested?**

+ **Target Platform:**

+ **Configuration Information:**

+ **Misc:** 

<!-- * More related information if you have can provide * -->
